### PR TITLE
Add multi-column display

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -24,13 +24,13 @@ h1, p {
 	padding-bottom:100px;
 }
 
-#links {
+.links {
 	margin: 0em auto;
 	max-width: 20em;
 	min-width: 200px;
 }
 
-#links a {
+.links a {
 	display: block;
 	background: #FCFCFC;
 	margin: 5px auto;
@@ -44,7 +44,7 @@ h1, p {
 	text-align: center;
 }
 
-#links a.down {
+.links a.down {
 	background: #F66F66;
 }
 

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -22,10 +22,16 @@ h1, p {
 
 #content {
 	padding-bottom:100px;
+	margin: 0em auto;
+	overflow: auto;
+	display: block;
+	text-align: center;
 }
 
 .links {
-	margin: 0em auto;
+	display: inline-block;
+	vertical-align: top;
+	margin: 0em 5px;
 	max-width: 20em;
 	min-width: 200px;
 }
@@ -41,7 +47,6 @@ h1, p {
 	color: #2F2F2F;
 	width: 100%;
 	vertical-align: middle;
-	text-align: center;
 }
 
 .links a.down {

--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@
 	</div>
 	<div id="content">
 		<div class="links">
-			
+			<h3>General</h3>
 			<a id="my-aberdeen" title="Essay submission, course resources, recorded lectures and more" accesskey="m" href="https://abdn.blackboard.com/webapps/login/">MyAberdeen</a>
 			<a id="my-curriculum" title="Course Selection" accesskey="c" href="https://onesourcesss.abdn.ac.uk/selfservice/">MyCurriculum</a>
 			<a id="my-timetable" title="Tutorial/lab/practical registration and viewing your degree's timetable" accesskey="t" href="https://www.abdn.ac.uk/mytimetable/session/login">MyTimetable</a>
@@ -43,12 +43,16 @@
 			<a id="printer-credits" title="Manage your printer credits" accesskey="x" href="https://printmanage.abdn.ac.uk/safecom/">Printer Credits</a>
 			<a id="week-numbers" title="What people mean when they say 'practicals start in week x'" accesskey="w" href="http://www.abdn.ac.uk/infohub/study/week-numbers-634.php">Week Numbers</a>
 			<a id="term-dates" title="Term and graduation dates" accesskey="d" href="http://www.abdn.ac.uk/infohub/study/term-dates-201415-631.php">Term Dates</a>
-			
+		</div>
+		
+		<div class="links">
 			<h3>Admin</h3>
 			<a id="e-registration" title="Registering for the upcoming year" accesskey="r" href="https://ereg.abdn.ac.uk/pls/custom_orasso/orasso.abdn_sso_login_er.abdn_sso_login_page?site2pstoretoken=v1.2">eRegistration</a>
 			<a id="student-portal" title="Exam timetables, exam results, books on loan and more" accesskey="p" href="http://studportal.abdn.ac.uk/portal/page?_pageid=35,1,35_3226&_dad=portal">Student Portal</a>
 			<a id="payments" title="Making payments to the university" accesskey="e" href="http://cmis.admin.abdn.ac.uk:81/pls/epayown/epayown.abdn_public_payment.public_payment_page">Electronic Payments</a>
-			
+		</div>
+		
+		<div class="links">
 			<h3>Available PCs</h3>
 			<a id="free-pcs" title="Available PCs in classrooms on campus" accesskey="f" href="http://www.abdn.ac.uk/freepcs/">Old Aberdeen Campus</a>
 			<a id="free-lib-pcs" title="Available PCs in the Sir Duncan Rice Library" accesskey="g" href="http://www.abdn.ac.uk/freepcs/LIB/">Library</a>

--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@
 		</div>
 	</div>
 	<div id="content">
-		<div id="links">
+		<div class="links">
 			
 			<a id="my-aberdeen" title="Essay submission, course resources, recorded lectures and more" accesskey="m" href="https://abdn.blackboard.com/webapps/login/">MyAberdeen</a>
 			<a id="my-curriculum" title="Course Selection" accesskey="c" href="https://onesourcesss.abdn.ac.uk/selfservice/">MyCurriculum</a>


### PR DESCRIPTION
This branch adds the capability for the link sections to be displayed next to each other on wider displays. This makes much better use of the otherwise wasted margins.

The feature is implemented via the CSS property `inline-block` with no trickery/hacks. The feature is fully responsive and the site continues to display as a single column on narrower displays such as mobile screens (#2).
